### PR TITLE
Catch遍历图片时的图片大小获取error

### DIFF
--- a/src-electron/traverseFolder.ts
+++ b/src-electron/traverseFolder.ts
@@ -84,11 +84,11 @@ function traverseFolderObjects (currentPath) {
           srcThumb: 'atom://' + filePath
         });
         picMetaMap.set(filePath, picLinks.length - 1);
-        const dimensions = sizeOf(filePath);
-        // console.log(dimensions.width, dimensions.height);
-        // console.log(filePath);
-        picLinks[picMetaMap.get(filePath)].height = dimensions.height;
-        picLinks[picMetaMap.get(filePath)].width = dimensions.width;
+        try{
+          const dimensions = sizeOf(filePath);
+          picLinks[picMetaMap.get(filePath)].height = dimensions.height;
+          picLinks[picMetaMap.get(filePath)].width = dimensions.width;
+        }catch (err) {}
         // console.log(picLinks[picMetaMap.get(filePath)]);
 
         // 异步方案，有问题


### PR DESCRIPTION
![image](https://github.com/Edge-coordinates/Waterfall_picture_viewer/assets/60863804/87b0a604-f879-42be-8e96-528f47c98940)
在遍历文件时，一个图片的数据错误导致图片大小读取错误将导致整个程序卡死（如图），所以在遍历图片时捕获此类错误防止无法加载瀑布流。